### PR TITLE
Small updates to make the example script run straight away

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ How to use it?
             source_db="ecoinvent 3.8 cutoff",
             source_version="3.8",
             key='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
-            custom_scenario=[
+            external_scenarios=[
                 bread_scenario, # <-- list datapackage objects here
             ] 
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pyyaml
 schema
 premise
 datapackage
-git+https://github.com/brightway-lca/brightway2-io.git
+brightway2


### PR DESCRIPTION
- add brightway2 to dependencies

Brightway2 is available on pip and must be completely imported
(not just brightway-io) for the example script to work straight away.

- NewDatabase parameter name in README

The custom_scenario parameter has been replaced by external_scenarios
in Premise. This change has to be made in the README.